### PR TITLE
feat #5 테스트 어려운 영역 분리하여 깨지지 않는 테스트 만들기

### DIFF
--- a/src/main/java/sample/cafekiosk/unit/CafeKiosk.java
+++ b/src/main/java/sample/cafekiosk/unit/CafeKiosk.java
@@ -4,18 +4,30 @@ import lombok.Getter;
 import sample.cafekiosk.unit.berverage.Berverage;
 import sample.cafekiosk.unit.order.Order;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 public class CafeKiosk {
 
+
+    public static final LocalTime SHOP_OPEN_TIME = LocalTime.of(10, 0);
+    public static final LocalTime SHOP_CLOSE_TIME = LocalTime.of(22, 0);
+
+
     private final List<Berverage> berverages = new ArrayList<>();
+
+
+    public void add(Berverage berverage) {
+        berverages.add(berverage);
+    }
 
     public void add(Berverage berverage, int count) {
 
-        if(count <= 0){
+        if (count <= 0) {
             throw new IllegalArgumentException("음료의 수량은 0보다 작을 수 없습니다.");
         }
 
@@ -43,6 +55,24 @@ public class CafeKiosk {
 
 
     public Order createOrder() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalTime currentTime = now.toLocalTime();
+
+        if (currentTime.isBefore(SHOP_OPEN_TIME) || currentTime.isAfter(SHOP_CLOSE_TIME)) {
+            throw new IllegalArgumentException("현재 주문이 가능한 시간이 아닙니다.");
+        }
+
+        return new Order(LocalDateTime.now(), berverages);
+    }
+
+
+    public Order createOrder(LocalDateTime now) {
+        LocalTime currentTime = now.toLocalTime();
+
+        if (currentTime.isBefore(SHOP_OPEN_TIME) || currentTime.isAfter(SHOP_CLOSE_TIME)) {
+            throw new IllegalArgumentException("현재 주문이 가능한 시간이 아닙니다.");
+        }
+
         return new Order(LocalDateTime.now(), berverages);
     }
 

--- a/src/test/java/sample/cafekiosk/unit/CafeKioskTest.java
+++ b/src/test/java/sample/cafekiosk/unit/CafeKioskTest.java
@@ -3,6 +3,10 @@ package sample.cafekiosk.unit;
 import org.junit.jupiter.api.Test;
 import sample.cafekiosk.unit.berverage.Americano;
 import sample.cafekiosk.unit.berverage.Latte;
+import sample.cafekiosk.unit.order.Order;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -86,6 +90,49 @@ class CafeKioskTest {
 
         cafeKiosk.clear();
         assertThat(cafeKiosk.getBerverages().size()).isEqualTo(0);
+    }
+
+
+
+    @Test
+    void createOrder(){ // 이 친구는 항상 성공하는 테스트가 아님! 시간 따라 결과가 달라짐!
+        CafeKiosk cafeKiosk = new CafeKiosk();
+
+        Americano americano = new Americano();
+        cafeKiosk.add(americano);
+
+        Order order = cafeKiosk.createOrder();
+
+        assertThat(order.getBerverages()).hasSize(1);
+        assertThat(order.getBerverages().get(0).getName()).isEqualTo("아메리카노");
+    }
+
+
+    @Test
+    void createOrderWithCurrentTime(){
+        CafeKiosk cafeKiosk = new CafeKiosk();
+
+        Americano americano = new Americano();
+        cafeKiosk.add(americano);
+
+        Order order = cafeKiosk.createOrder(LocalDateTime.of(2024,11,5,10,0));
+
+        assertThat(order.getBerverages()).hasSize(1);
+        assertThat(order.getBerverages().get(0).getName()).isEqualTo("아메리카노");
+    }
+
+
+    @Test
+    void createOrderOutsideOpenTime(){
+        CafeKiosk cafeKiosk = new CafeKiosk();
+
+        Americano americano = new Americano();
+        cafeKiosk.add(americano);
+
+
+        assertThatThrownBy(() -> cafeKiosk.createOrder(LocalDateTime.of(2024,11,5,9,59)))
+                .isInstanceOf((IllegalArgumentException.class))
+                .hasMessage("현재 주문이 가능한 시간이 아닙니다.");
     }
 
 


### PR DESCRIPTION
### 새로운 요구사항 등장

가게 운영 시간 외에는 주문을 생성할 수 없다.(1000~2200) 외에 할 수 없음!

이렇게 되었을 경우 테스트 코드를 작성할 때 어떤 점을 유의해야하나?

### 매번 바뀌거나 내 코드가 외부에 영향을 주는 코드

- 관측할 때마다 변할 수 있는 값
    - 현재 날짜/시간
    - 랜덤 값
    - 전역 변수/함수
    - 사용자 입력
- 외부에 영향
    - 표준 출력
    - 메시지 발송
    - db 에 기록

아래 테스트를 보자! 대표적인 값이 관측할 때마다 테스트가 깨질 수 있는 코드다(LocalDateTime.now()) 에 따라서 테스트가 성공/실패 둘 다 할 수 있다.


https://github.com/khyojun/Practical-Testing-practice/blob/bbed31a4f1a1fb068dcec1b93b73ccaf622ea666/src/main/java/sample/cafekiosk/unit/CafeKiosk.java#L57-L66
 	

https://github.com/khyojun/Practical-Testing-practice/blob/bbed31a4f1a1fb068dcec1b93b73ccaf622ea666/src/test/java/sample/cafekiosk/unit/CafeKioskTest.java#L97-L108


이런 경우 order의 createOrder 같은 경우는 테스트하기가 어렵다고 표현한다! 마찬가지 외부에 영향을 주는 코드도 있다.

### 우째할까? → 조금 어려운 영역을 내부가 아니라 외부에서 받을 수 있도록?


https://github.com/khyojun/Practical-Testing-practice/blob/bbed31a4f1a1fb068dcec1b93b73ccaf622ea666/src/main/java/sample/cafekiosk/unit/CafeKiosk.java#L69-L77



https://github.com/khyojun/Practical-Testing-practice/blob/bbed31a4f1a1fb068dcec1b93b73ccaf622ea666/src/test/java/sample/cafekiosk/unit/CafeKioskTest.java#L111-L136





이렇게 변경하게 되었을 경우에는 이제 외부에서 파라미터 값으로 받아오는 형태로 변환되어 분리시켜줬기 때문에 우리가 현재 시간이라는 값을 임의로 설정하여 테스트 하여 어느 상황에서라도 깨지지 않는 테스트를 수행할 수 있게 된다.

이렇게 항상 `같은 입력에는 항상 같은 결과`

`외부와는 단절 된 형태`를 함수형 프로그래밍에서 `순수 함수`라고 부르고 

이런 코드를 테스트하기 쉬운 코드라고 부른다!

### 그래서 핵심 : 테스트 하기 어려운 영역이 어딘지 확인하고 분리하는 시야를 길러야 한다.


closes #5 


