### PR TITLE
Feat#17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,10 @@ repositories {
 
 dependencies {
 
-    //spring
+    //spring boot
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     //test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/sample/cafekiosk/spring/CafekioskApplication.java
+++ b/src/main/java/sample/cafekiosk/spring/CafekioskApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class CafekioskApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/sample/cafekiosk/spring/api/ApiControllerAdvice.java
+++ b/src/main/java/sample/cafekiosk/spring/api/ApiControllerAdvice.java
@@ -1,0 +1,24 @@
+package sample.cafekiosk.spring.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindException;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+
+@RestControllerAdvice
+public class ApiControllerAdvice {
+
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(BindException.class)
+    public ApiResponse<Object> bindException(BindException e) {
+        return ApiResponse.of(HttpStatus.BAD_REQUEST,
+                e.getBindingResult().getAllErrors().get(0).getDefaultMessage(),
+                null
+                );
+    }
+
+}

--- a/src/main/java/sample/cafekiosk/spring/api/ApiResponse.java
+++ b/src/main/java/sample/cafekiosk/spring/api/ApiResponse.java
@@ -1,0 +1,36 @@
+package sample.cafekiosk.spring.api;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import sample.cafekiosk.spring.api.service.product.response.ProductResponse;
+
+@Getter
+public class ApiResponse<T> {
+
+    private int code;
+    private HttpStatus status;
+    private String message;
+    private T data;
+
+
+    public ApiResponse(HttpStatus status, String message, T data) {
+        this.code = status.value();
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> of(HttpStatus status, String message, T data) {
+        return new ApiResponse<>(status, message, data);
+    }
+
+    public static <T> ApiResponse<T> of(HttpStatus status, T data) {
+        return of(status, status.name(), data);
+    }
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return of(HttpStatus.OK, HttpStatus.OK.name(), data);
+    }
+
+}

--- a/src/main/java/sample/cafekiosk/spring/api/controller/order/OrderController.java
+++ b/src/main/java/sample/cafekiosk/spring/api/controller/order/OrderController.java
@@ -1,11 +1,14 @@
 package sample.cafekiosk.spring.api.controller.order;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import sample.cafekiosk.spring.api.ApiResponse;
+import sample.cafekiosk.spring.api.controller.order.request.OrderCreateRequest;
 import sample.cafekiosk.spring.api.service.order.OrderService;
-import sample.cafekiosk.spring.api.service.order.request.OrderCreateRequest;
+import sample.cafekiosk.spring.api.service.order.request.OrderCreateServiceRequest;
 import sample.cafekiosk.spring.api.service.order.response.OrderResponse;
 
 import java.time.LocalDateTime;
@@ -16,11 +19,10 @@ public class OrderController {
 
     private final OrderService orderService;
 
-
     @PostMapping("/api/v1/orders/new")
-    public OrderResponse createOrder(@RequestBody OrderCreateRequest request){
+    public ApiResponse<OrderResponse> createOrder(@Valid @RequestBody OrderCreateRequest request){
         LocalDateTime now = LocalDateTime.now();
-        return orderService.createOrder(request, now);
+        return ApiResponse.ok(orderService.createOrder(request.toServiceRequest(), now));
     }
 
 

--- a/src/main/java/sample/cafekiosk/spring/api/controller/order/request/OrderCreateRequest.java
+++ b/src/main/java/sample/cafekiosk/spring/api/controller/order/request/OrderCreateRequest.java
@@ -1,0 +1,34 @@
+package sample.cafekiosk.spring.api.controller.order.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sample.cafekiosk.spring.api.service.order.request.OrderCreateServiceRequest;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class OrderCreateRequest {
+    // controller dto 에서만 validation 로직을 분리하여 진행하는 방식이 좋아보임!
+    // 귀찮긴 함! 너무 그럼! 서비스가 커지면 커질수록 이 작업 또한 부담일 수 있음!
+    // 나중에 포스키 주문을 받을수도 사이렌 오더에서 받을수도 있고, 주문 받는 채널이 여러개가 될 수 있음!
+    // 나는 같은 서비스를 사용하고 싶은데 만약 컨트롤러 dto 그대로 받아버리면 이거 이렇게 받으면 안될건데? 하고 하는 문제가 일어날 수 있음!
+    // 그래서 너무너무 귀찮지만 분리해주는 작업들이 너무 필요하다! -> 숲은 보자~
+    @NotEmpty(message = "상품 번호는 필수입니다.")
+    private List<String> productNumbers;
+
+
+    @Builder
+    private OrderCreateRequest(List<String> productNumbers) {
+        this.productNumbers = productNumbers;
+    }
+
+
+    public OrderCreateServiceRequest toServiceRequest(){
+        return OrderCreateServiceRequest.builder()
+                .productNumbers(productNumbers)
+                .build();
+    }
+}

--- a/src/main/java/sample/cafekiosk/spring/api/controller/product/ProductController.java
+++ b/src/main/java/sample/cafekiosk/spring/api/controller/product/ProductController.java
@@ -2,7 +2,9 @@ package sample.cafekiosk.spring.api.controller.product;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
+import sample.cafekiosk.spring.api.controller.product.dto.request.ProductCreateRequest;
 import sample.cafekiosk.spring.api.service.product.ProductService;
 import sample.cafekiosk.spring.api.service.product.response.ProductResponse;
 
@@ -14,6 +16,11 @@ public class ProductController {
 
     private final ProductService productService;
 
+    @PostMapping("/api/v1/products/new")
+    public void createProduct(ProductCreateRequest request){
+        productService.createProduct(request);
+
+    }
 
 
     @GetMapping("/api/v1/products/selling")

--- a/src/main/java/sample/cafekiosk/spring/api/controller/product/ProductController.java
+++ b/src/main/java/sample/cafekiosk/spring/api/controller/product/ProductController.java
@@ -1,9 +1,13 @@
 package sample.cafekiosk.spring.api.controller.product;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import sample.cafekiosk.spring.api.ApiResponse;
 import sample.cafekiosk.spring.api.controller.product.dto.request.ProductCreateRequest;
 import sample.cafekiosk.spring.api.service.product.ProductService;
 import sample.cafekiosk.spring.api.service.product.response.ProductResponse;
@@ -17,15 +21,14 @@ public class ProductController {
     private final ProductService productService;
 
     @PostMapping("/api/v1/products/new")
-    public void createProduct(ProductCreateRequest request){
-        productService.createProduct(request);
-
+    public ApiResponse<ProductResponse> createProduct(@Valid @RequestBody ProductCreateRequest request){
+        return ApiResponse.of(HttpStatus.OK, productService.createProduct(request.toServiceRequest()));
     }
 
 
     @GetMapping("/api/v1/products/selling")
-    public List<ProductResponse> getSellingProducts(){
-        return productService.getSellingProducts();
+    public ApiResponse<List<ProductResponse>> getSellingProducts(){
+        return ApiResponse.ok(productService.getSellingProducts());
     }
 
 }

--- a/src/main/java/sample/cafekiosk/spring/api/controller/product/dto/request/ProductCreateRequest.java
+++ b/src/main/java/sample/cafekiosk/spring/api/controller/product/dto/request/ProductCreateRequest.java
@@ -1,0 +1,35 @@
+package sample.cafekiosk.spring.api.controller.product.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import sample.cafekiosk.spring.domain.product.Product;
+import sample.cafekiosk.spring.domain.product.ProductSellingStatus;
+import sample.cafekiosk.spring.domain.product.ProductType;
+
+@Getter
+public class ProductCreateRequest {
+
+    private String name;
+    private ProductType type;
+    private ProductSellingStatus sellingStatus;
+    private int price;
+
+
+    @Builder
+    private ProductCreateRequest(String name, ProductType type, ProductSellingStatus sellingStatus, int price) {
+        this.name = name;
+        this.type = type;
+        this.sellingStatus = sellingStatus;
+        this.price = price;
+    }
+
+    public Product toEntity(String nextProductNumber) {
+        return Product.builder()
+                .productNumber(nextProductNumber)
+                .name(name)
+                .type(type)
+                .price(price)
+                .sellingStatus(sellingStatus)
+                .build();
+    }
+}

--- a/src/main/java/sample/cafekiosk/spring/api/controller/product/dto/request/ProductCreateRequest.java
+++ b/src/main/java/sample/cafekiosk/spring/api/controller/product/dto/request/ProductCreateRequest.java
@@ -1,17 +1,32 @@
 package sample.cafekiosk.spring.api.controller.product.dto.request;
 
+import jakarta.validation.constraints.*;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sample.cafekiosk.spring.api.service.product.request.ProductServiceRequest;
 import sample.cafekiosk.spring.domain.product.Product;
 import sample.cafekiosk.spring.domain.product.ProductSellingStatus;
 import sample.cafekiosk.spring.domain.product.ProductType;
 
 @Getter
+@NoArgsConstructor
 public class ProductCreateRequest {
 
+    @NotBlank(message = "상품 이름은 필수입니다.")// notblank는 문자가 필수로 있어야 한다!
+    //@NotNull // "" "  " 요건 허용이 됨!
+    //@NotEmpty // ""  이것만 아니면 통과! 공백은 허용!
+    // String name -> 상품 이름은 20자 제한 이렇게 도메인 정책
+    //@Max(20) // 이걸 여기서 해야하는게 맞나? 책임이 맞나? 고민해봐야함!
+    // 왜냐? 우리만 사실 도메인 정책에서 사용하는 그런 성격의 정책이라면? 특수한 정책이라면? 구분해야함!
+    // 그래서 우리는 하나의 밸리데이션으로 보이더라도 어느 레이어에서 검증할지 한 번에 한 레이어에서 할 필요는 없음!
+    // 책임을 어떻게 분리하면 좋을지 생각!
     private String name;
+    @NotNull(message = "상품 타입은 필수입니다.")
     private ProductType type;
+    @NotNull(message = "상품 판매상태는 필수입니다.")
     private ProductSellingStatus sellingStatus;
+    @Positive(message = "상품 가격은 양수여야 합니다.")
     private int price;
 
 
@@ -23,13 +38,15 @@ public class ProductCreateRequest {
         this.price = price;
     }
 
-    public Product toEntity(String nextProductNumber) {
-        return Product.builder()
-                .productNumber(nextProductNumber)
+
+    public ProductServiceRequest toServiceRequest(){
+        return ProductServiceRequest.builder()
                 .name(name)
                 .type(type)
-                .price(price)
                 .sellingStatus(sellingStatus)
+                .price(price)
                 .build();
     }
+
+
 }

--- a/src/main/java/sample/cafekiosk/spring/api/service/order/OrderService.java
+++ b/src/main/java/sample/cafekiosk/spring/api/service/order/OrderService.java
@@ -3,7 +3,7 @@ package sample.cafekiosk.spring.api.service.order;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import sample.cafekiosk.spring.api.service.order.request.OrderCreateRequest;
+import sample.cafekiosk.spring.api.service.order.request.OrderCreateServiceRequest;
 import sample.cafekiosk.spring.api.service.order.response.OrderResponse;
 import sample.cafekiosk.spring.domain.order.Order;
 import sample.cafekiosk.spring.domain.order.OrderRepository;
@@ -35,7 +35,10 @@ public class OrderService {
      * optimistic lock / pessimistic lock / ... locking 개념을 사용 순차적으로 처리될 수 있도록
      * 사실 이 키오스크 문제가 조금 복잡하게 있음!
      */
-    public OrderResponse createOrder(OrderCreateRequest request, LocalDateTime now) {
+    // 여기 request 가 controller에 의존하는 dto 가 파라미터에 있음!
+    // service 가 controller를 알고있음! layered 에서 가장 좋은 그림은 하위 레이어가 상위 레이어를 모르는 형태가 가장 좋음!
+    // 그래서 강사님은 서비스용 requestDto 를 만들고 진행하심!
+    public OrderResponse createOrder(OrderCreateServiceRequest request, LocalDateTime now) {
         List<String> productNumbers = request.getProductNumbers();
         //Product
         List<Product> products = findProductsBy(productNumbers);

--- a/src/main/java/sample/cafekiosk/spring/api/service/order/request/OrderCreateServiceRequest.java
+++ b/src/main/java/sample/cafekiosk/spring/api/service/order/request/OrderCreateServiceRequest.java
@@ -8,13 +8,13 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
-public class OrderCreateRequest {
+public class OrderCreateServiceRequest {
 
     private List<String> productNumbers;
 
-
+    // 귀찮겠지만 프레젠테이션 레이어에서
     @Builder
-    private OrderCreateRequest(List<String> productNumbers) {
+    private OrderCreateServiceRequest(List<String> productNumbers) {
         this.productNumbers = productNumbers;
     }
 }

--- a/src/main/java/sample/cafekiosk/spring/api/service/product/ProductService.java
+++ b/src/main/java/sample/cafekiosk/spring/api/service/product/ProductService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sample.cafekiosk.spring.api.controller.product.dto.request.ProductCreateRequest;
+import sample.cafekiosk.spring.api.service.product.request.ProductServiceRequest;
 import sample.cafekiosk.spring.api.service.product.response.ProductResponse;
 import sample.cafekiosk.spring.domain.product.Product;
 import sample.cafekiosk.spring.domain.product.ProductRepository;
@@ -43,7 +44,7 @@ public class ProductService {
     // 방법은 여러가지 unique index 이용해서 재시도 하는 방식
     // 동시접속이 한 번에 너무 ㅁ낳이 나오면! UUID 같은 것으로 해결하는 방식
     @Transactional
-    public ProductResponse createProduct(ProductCreateRequest request) {
+    public ProductResponse createProduct(ProductServiceRequest request) {
         // nextProductNumber
         String nextProductNumber = createNextProductNumber();
 

--- a/src/main/java/sample/cafekiosk/spring/api/service/product/ProductService.java
+++ b/src/main/java/sample/cafekiosk/spring/api/service/product/ProductService.java
@@ -2,6 +2,8 @@ package sample.cafekiosk.spring.api.service.product;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sample.cafekiosk.spring.api.controller.product.dto.request.ProductCreateRequest;
 import sample.cafekiosk.spring.api.service.product.response.ProductResponse;
 import sample.cafekiosk.spring.domain.product.Product;
 import sample.cafekiosk.spring.domain.product.ProductRepository;
@@ -9,6 +11,26 @@ import sample.cafekiosk.spring.domain.product.ProductSellingStatus;
 
 import java.util.List;
 
+
+/**
+ * readOnly = true 관련 얘기
+ * 읽기 전용 트랜잭션 진행
+ * crud 중 cud 작업은 동작을 안함! onlyRead만 할 수 있는 형태
+ * 조회만 가능
+ * JPA : CUD 스냅샷 저장, 변경감지 X (성능 향상)
+ * CQRS - Command랑 Query를 분리하자! 이거임 줄여 말하면 -> read 라는 행위가 빈도수가 거진 2:8 정도로 높음
+ * 이 친구의 시작으로 readOnly를 true로 하는것부터 이것의 시작이라고 생각함!
+ * query용 서비스 command용 서비스를 분리할 수도 있음!
+ * command - cud : 이 작업을 위한 친구를 분리할 수 있음!
+ * 가장 좋은 포인트! db에 대한 엔드포인트를 분리할 수 있음 aws aurora ~~ read용 db, write용 db를 같이 분리를 하게 할 수 있음
+ * writer db에 대한 엔드포인트 slave db에 대한 엔드포인트를 나누고 readOnly true가 걸리면 읽기 전용 db로 보내고 아니면 writer 전용 db로 보내기
+ * aurora db 클러스터 모드를 쓰면 readOnly만 보고 분리해주는 친구도 있음!
+ * spring에 readOnly값을 보고 엔드포인트 다르게 줄 수도 있음!
+ * 하고 싶은 말은! transactional 에 잘 걸기로 했는데! readOnly true 에 대한 것을 query용 행위, command용 행위에 잘 나눠서 달았으면 좋겠음!ㄸ
+ * method 마다 달게 되면 누락이 될 수 있는 실수를 할 수 있다는 문제가 있음!
+ * 추천하는 방법은 service 클래스 상단에 readOnly 를 걸어버리고 cud 작업이 있따면 method 단위에서 transactional 걸어버리는 것을 추천!
+ */
+@Transactional(readOnly = true)
 @Service
 @RequiredArgsConstructor
 public class ProductService {
@@ -16,6 +38,36 @@ public class ProductService {
     private final ProductRepository productRepository;
 
 
+
+    // 동시성 이슈 발생 가능성 있음!
+    // 방법은 여러가지 unique index 이용해서 재시도 하는 방식
+    // 동시접속이 한 번에 너무 ㅁ낳이 나오면! UUID 같은 것으로 해결하는 방식
+    @Transactional
+    public ProductResponse createProduct(ProductCreateRequest request) {
+        // nextProductNumber
+        String nextProductNumber = createNextProductNumber();
+
+        Product product = request.toEntity(nextProductNumber);
+        Product savedProduct = productRepository.save(product);
+
+        return ProductResponse.of(savedProduct);
+    }
+
+    private String createNextProductNumber() {
+        String latestProductNumber = productRepository.findLatestProduct();
+        if(latestProductNumber == null){
+            return "001";
+        }
+
+        int latestProductNumberInt = Integer.parseInt(latestProductNumber);
+        int nextProductNumberInt = latestProductNumberInt + 1;
+
+        return String.format("%03d", nextProductNumberInt);
+    }
+
+
+
+    @Transactional(readOnly = true)
     public List<ProductResponse> getSellingProducts(){
         List<Product> products = productRepository.findAllBySellingStatusIn(ProductSellingStatus.forDisplay());
 

--- a/src/main/java/sample/cafekiosk/spring/api/service/product/request/ProductServiceRequest.java
+++ b/src/main/java/sample/cafekiosk/spring/api/service/product/request/ProductServiceRequest.java
@@ -1,0 +1,36 @@
+package sample.cafekiosk.spring.api.service.product.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Builder;
+import sample.cafekiosk.spring.domain.product.Product;
+import sample.cafekiosk.spring.domain.product.ProductSellingStatus;
+import sample.cafekiosk.spring.domain.product.ProductType;
+
+public class ProductServiceRequest {
+    private String name;
+    private ProductType type;
+    private ProductSellingStatus sellingStatus;
+    private int price;
+
+
+    @Builder
+    private ProductServiceRequest(String name, ProductType type, ProductSellingStatus sellingStatus, int price) {
+        this.name = name;
+        this.type = type;
+        this.sellingStatus = sellingStatus;
+        this.price = price;
+    }
+
+    public Product toEntity(String nextProductNumber) {
+        return Product.builder()
+                .productNumber(nextProductNumber)
+                .name(name)
+                .type(type)
+                .price(price)
+                .sellingStatus(sellingStatus)
+                .build();
+    }
+
+}

--- a/src/main/java/sample/cafekiosk/spring/api/service/product/response/ProductResponse.java
+++ b/src/main/java/sample/cafekiosk/spring/api/service/product/response/ProductResponse.java
@@ -12,16 +12,16 @@ public class ProductResponse {
     private Long id;
     private String productNumber;
     private ProductType type;
-    private ProductSellingStatus sellingType;
+    private ProductSellingStatus sellingStatus;
     private String name;
     private int price;
 
     @Builder
-    private ProductResponse(Long id, String productNumber, String name, ProductType type, ProductSellingStatus sellingType, int price) {
+    private ProductResponse(Long id, String productNumber, String name, ProductType type, ProductSellingStatus sellingStatus, int price) {
         this.id = id;
         this.productNumber = productNumber;
         this.type = type;
-        this.sellingType = sellingType;
+        this.sellingStatus = sellingStatus;
         this.name = name;
         this.price = price;
     }
@@ -31,7 +31,7 @@ public class ProductResponse {
                 .id(product.getId())
                 .productNumber(product.getProductNumber())
                 .type(product.getType())
-                .sellingType(product.getSellingStatus())
+                .sellingStatus(product.getSellingStatus())
                 .name(product.getName())
                 .price(product.getPrice())
                 .build();

--- a/src/main/java/sample/cafekiosk/spring/config/JpaAuditingConfig.java
+++ b/src/main/java/sample/cafekiosk/spring/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package sample.cafekiosk.spring.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+}

--- a/src/main/java/sample/cafekiosk/spring/domain/product/ProductRepository.java
+++ b/src/main/java/sample/cafekiosk/spring/domain/product/ProductRepository.java
@@ -1,6 +1,7 @@
 package sample.cafekiosk.spring.domain.product;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -20,4 +21,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     List<Product> findAllByProductNumberIn(List<String> productNumbers);
 
 
+    @Query(value = "select p.product_number from Product p order by id desc limit 1", nativeQuery = true)
+    String findLatestProduct(); // 뭐 repository 구현 내용에 관계없이 작성을 해야한다. 라는게 중요했음 테스트코드 관련해서 어떤 형태든 상관없음
 }

--- a/src/test/java/sample/cafekiosk/spring/api/controller/order/OrderControllerTest.java
+++ b/src/test/java/sample/cafekiosk/spring/api/controller/order/OrderControllerTest.java
@@ -1,0 +1,77 @@
+package sample.cafekiosk.spring.api.controller.order;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import sample.cafekiosk.spring.api.service.order.OrderService;
+import sample.cafekiosk.spring.api.service.order.request.OrderCreateServiceRequest;
+
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = OrderController.class)
+class OrderControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private OrderService orderService;
+//
+
+
+    @DisplayName("신규 주문을 등록한다.")
+    @Test
+    void createOrder() throws Exception {
+        //given
+        OrderCreateServiceRequest request = OrderCreateServiceRequest.builder()
+                .productNumbers(List.of("001", "002"))
+                .build();
+
+
+        //when //then
+        mockMvc.perform(post("/api/v1/orders/new")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"));
+    }
+
+
+    @DisplayName("신규 주문 등록시 상품 번호들은 필수로 들어가야 한다.")
+    @Test
+    void createOrderWithoutProductNumbers() throws Exception {
+        //given
+        OrderCreateServiceRequest request = OrderCreateServiceRequest.builder()
+                .productNumbers(List.of())
+                .build();
+
+        //when //then
+        mockMvc.perform(post("/api/v1/orders/new")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("상품 번호는 필수입니다."))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+}

--- a/src/test/java/sample/cafekiosk/spring/api/controller/product/ProductControllerTest.java
+++ b/src/test/java/sample/cafekiosk/spring/api/controller/product/ProductControllerTest.java
@@ -1,0 +1,182 @@
+package sample.cafekiosk.spring.api.controller.product;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import sample.cafekiosk.spring.api.controller.product.dto.request.ProductCreateRequest;
+import sample.cafekiosk.spring.api.service.product.ProductService;
+import sample.cafekiosk.spring.api.service.product.response.ProductResponse;
+import sample.cafekiosk.spring.domain.product.ProductSellingStatus;
+import sample.cafekiosk.spring.domain.product.ProductType;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@WebMvcTest(controllers = ProductController.class)
+class ProductControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc; // 이 친구랑 webMvcTest 랑 함께 사용
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean // Mockito 를 사용하는 친구
+    private ProductService productService;
+
+
+    @DisplayName("신규 상품을 등록한다.")
+    @Test
+    void createProduct() throws Exception {
+        //given
+        ProductCreateRequest request = ProductCreateRequest.builder()
+                .type(ProductType.HANDMADE)
+                .sellingStatus(ProductSellingStatus.SELLING)
+                .name("아메리카노")
+                .price(4000)
+                .build();
+
+        //when //then
+        mockMvc.perform(post("/api/v1/products/new")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+
+    @DisplayName("신규 상품을 등록할 때 상품 타입은 필수값이다.")
+    @Test
+    void createProductWithoutType() throws Exception {
+        //given
+        ProductCreateRequest request = ProductCreateRequest.builder()
+                .sellingStatus(ProductSellingStatus.SELLING)
+                .name("아메리카노")
+                .price(4000)
+                .build();
+
+        //when //then
+        mockMvc.perform(post("/api/v1/products/new")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("상품 타입은 필수입니다."))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+
+    @DisplayName("신규 상품을 등록할 때 상품 판매상태는 필수값이다.")
+    @Test
+    void createProductWithoutSellingStatus() throws Exception {
+        //given
+        ProductCreateRequest request = ProductCreateRequest.builder()
+                .type(ProductType.HANDMADE)
+                .name("아메리카노")
+                .price(4000)
+                .build();
+
+        //when //then
+        mockMvc.perform(post("/api/v1/products/new")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("상품 판매상태는 필수입니다."))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+
+    @DisplayName("신규 상품을 등록할 때 상품 이름은 필수값이다.")
+    @Test
+    void createProductWithoutName() throws Exception {
+        //given
+        ProductCreateRequest request = ProductCreateRequest.builder()
+                .type(ProductType.HANDMADE)
+                .sellingStatus(ProductSellingStatus.SELLING)
+                .price(4000)
+                .build();
+
+        //when //then
+        mockMvc.perform(post("/api/v1/products/new")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("상품 이름은 필수입니다."))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+
+    @DisplayName("신규 상품을 등록할 때 상품 가격은 양수여야 한다.")
+    @Test
+    void createProductWithoutPositivePrice() throws Exception {
+        //given
+        ProductCreateRequest request = ProductCreateRequest.builder()
+                .type(ProductType.HANDMADE)
+                .sellingStatus(ProductSellingStatus.SELLING)
+                .name("아메리카노")
+                .price(0)
+                .build();
+
+        //when //then
+        mockMvc.perform(post("/api/v1/products/new")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("상품 가격은 양수여야 합니다."))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+
+    @DisplayName("판매 상품을 조회한다.")
+    @Test
+    void getSellingProducts() throws Exception {
+        //given
+        List<ProductResponse> result = List.of();
+        when(productService.getSellingProducts()).thenReturn(result);
+
+
+        //when //then
+        mockMvc.perform(get("/api/v1/products/selling")
+                        //.queryParam("name", "이름")
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data").isArray());
+    }
+
+
+}

--- a/src/test/java/sample/cafekiosk/spring/api/service/order/OrderServiceTest.java
+++ b/src/test/java/sample/cafekiosk/spring/api/service/order/OrderServiceTest.java
@@ -1,15 +1,13 @@
 package sample.cafekiosk.spring.api.service.order;
 
-import jakarta.transaction.Transactional;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import sample.cafekiosk.spring.api.service.order.request.OrderCreateRequest;
+import sample.cafekiosk.spring.api.service.order.request.OrderCreateServiceRequest;
 import sample.cafekiosk.spring.api.service.order.response.OrderResponse;
 import sample.cafekiosk.spring.domain.order.OrderRepository;
 import sample.cafekiosk.spring.domain.orderproduct.OrderProductRepository;
@@ -65,7 +63,7 @@ class OrderServiceTest {
         Product product2 = createProduct(ProductType.HANDMADE, "002", 3000);
         productRepository.saveAll(List.of(product1, product2));
 
-        OrderCreateRequest request = OrderCreateRequest.builder()
+        OrderCreateServiceRequest request = OrderCreateServiceRequest.builder()
                 .productNumbers(List.of("001", "002"))
                 .build();
 
@@ -104,7 +102,7 @@ class OrderServiceTest {
         Product product2 = createProduct(ProductType.HANDMADE, "002", 3000);
         productRepository.saveAll(List.of(product1, product2));
 
-        OrderCreateRequest request = OrderCreateRequest.builder()
+        OrderCreateServiceRequest request = OrderCreateServiceRequest.builder()
                 .productNumbers(List.of("001", "001"))
                 .build();
 
@@ -157,7 +155,7 @@ class OrderServiceTest {
 
         stockRepository.saveAll(List.of(stock1, stock2));
 
-        OrderCreateRequest request = OrderCreateRequest.builder()
+        OrderCreateServiceRequest request = OrderCreateServiceRequest.builder()
                 .productNumbers(List.of("001", "001", "002", "003"))
                 .build();
 
@@ -215,7 +213,7 @@ class OrderServiceTest {
 
         stockRepository.saveAll(List.of(stock1, stock2));
 
-        OrderCreateRequest request = OrderCreateRequest.builder()
+        OrderCreateServiceRequest request = OrderCreateServiceRequest.builder()
                 .productNumbers(List.of("001", "001", "002", "003"))
                 .build();
 

--- a/src/test/java/sample/cafekiosk/spring/api/service/product/ProductServiceTest.java
+++ b/src/test/java/sample/cafekiosk/spring/api/service/product/ProductServiceTest.java
@@ -1,0 +1,119 @@
+package sample.cafekiosk.spring.api.service.product;
+
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import sample.cafekiosk.spring.api.controller.product.dto.request.ProductCreateRequest;
+import sample.cafekiosk.spring.api.service.product.response.ProductResponse;
+import sample.cafekiosk.spring.domain.product.Product;
+import sample.cafekiosk.spring.domain.product.ProductRepository;
+import sample.cafekiosk.spring.domain.product.ProductSellingStatus;
+import sample.cafekiosk.spring.domain.product.ProductType;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ProductServiceTest {
+
+    @Autowired
+    private ProductService productService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+
+    @AfterEach
+    void tearDown() {
+        productRepository.deleteAllInBatch();
+    }
+
+    // 처음 규모가 작아졌을때 service 랑 repository 테스트랑 머가 다른지 잘 모를 때가 있음!
+    // 하지만 점차 발전해가면 갈수록 달라져가니 분리해서 작성하는 것이 좋을 듯
+    @DisplayName("신규 상품을 등록한다. 상품번호는 가장 최근 상품의 상품번호에서 1 증가한 값이다.")
+    @Test
+    void createProduct() {
+        //given
+        Product product1 = createProduct("001", ProductType.HANDMADE, ProductSellingStatus.SELLING, "아메리카노", 4000);
+       productRepository.save(product1);
+
+        ProductCreateRequest request = ProductCreateRequest.builder()
+                .type(ProductType.HANDMADE)
+                .sellingStatus(ProductSellingStatus.SELLING)
+                .name("카푸치노")
+                .price(5000)
+                .build();
+
+
+        //when
+        ProductResponse productResponse = productService.createProduct(request);
+
+
+        //then
+        assertThat(productResponse)
+                .extracting("productNumber", "type", "sellingStatus", "price", "name")
+                .contains("002", ProductType.HANDMADE, ProductSellingStatus.SELLING, 5000, "카푸치노");
+
+        List<Product> products = productRepository.findAll();
+        assertThat(products).hasSize(2)
+                .extracting("productNumber", "type", "sellingStatus", "price", "name")
+                .containsExactlyInAnyOrder(
+                        Tuple.tuple("001", ProductType.HANDMADE, ProductSellingStatus.SELLING, 4000, "아메리카노"),
+                        Tuple.tuple("002", ProductType.HANDMADE, ProductSellingStatus.SELLING, 5000, "카푸치노")
+                );
+
+
+    }
+
+
+    @DisplayName("상품이 하나도 없는 경우 신규 상품을 등록하면 상품번호는 001이다.")
+    @Test
+    void createProductWhenProductsIsEmpty() {
+        //given
+
+        ProductCreateRequest request = ProductCreateRequest.builder()
+                .type(ProductType.HANDMADE)
+                .sellingStatus(ProductSellingStatus.SELLING)
+                .name("카푸치노")
+                .price(5000)
+                .build();
+
+
+        //when
+        ProductResponse productResponse = productService.createProduct(request);
+
+
+        //then
+        assertThat(productResponse)
+                .extracting("productNumber", "type", "sellingStatus", "price", "name")
+                .contains("001", ProductType.HANDMADE, ProductSellingStatus.SELLING, 5000, "카푸치노");
+
+        List<Product> products = productRepository.findAll();
+        assertThat(products).hasSize(1)
+                .extracting("productNumber", "type", "sellingStatus", "price", "name")
+                .containsExactlyInAnyOrder(
+                        Tuple.tuple("001", ProductType.HANDMADE, ProductSellingStatus.SELLING, 5000, "카푸치노")
+                );
+    }
+
+
+    private Product createProduct(String productNumber, ProductType type, ProductSellingStatus sellingStatus
+            , String name, int price
+    ) {
+        return Product.builder()
+                .productNumber(productNumber)
+                .type(type)
+                .sellingStatus(sellingStatus)
+                .name(name)
+                .price(price)
+                .build();
+    }
+
+}

--- a/src/test/java/sample/cafekiosk/spring/api/service/product/ProductServiceTest.java
+++ b/src/test/java/sample/cafekiosk/spring/api/service/product/ProductServiceTest.java
@@ -53,7 +53,7 @@ class ProductServiceTest {
 
 
         //when
-        ProductResponse productResponse = productService.createProduct(request);
+        ProductResponse productResponse = productService.createProduct(request.toServiceRequest());
 
 
         //then
@@ -87,7 +87,7 @@ class ProductServiceTest {
 
 
         //when
-        ProductResponse productResponse = productService.createProduct(request);
+        ProductResponse productResponse = productService.createProduct(request.toServiceRequest());
 
 
         //then

--- a/src/test/java/sample/cafekiosk/spring/domain/product/ProductRepositoryTest.java
+++ b/src/test/java/sample/cafekiosk/spring/domain/product/ProductRepositoryTest.java
@@ -1,17 +1,15 @@
 package sample.cafekiosk.spring.domain.product;
 
-import org.assertj.core.api.Assertions;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 //@SpringBootTest // 결론 spring boot test를 선호하게 됨
 @DataJpaTest // springboot test 보다는 가벼움 -> jpa 관련 빈들만 주입
@@ -28,30 +26,11 @@ class ProductRepositoryTest {
     @Test
     void findAllBySellingStatusIn() {
         // given
-        Product product1 = Product.builder()
-                .productNumber("001")
-                .type(ProductType.HANDMADE)
-                .sellingStatus(ProductSellingStatus.SELLING)
-                .name("아메리카노")
-                .price(4000)
-                .build();
-
-        Product product2 = Product.builder()
-                .productNumber("002")
-                .type(ProductType.HANDMADE)
-                .sellingStatus(ProductSellingStatus.HOLD)
-                .name("카폐라떼")
-                .price(4500)
-                .build();
+        Product product1 = createProduct("001", ProductType.HANDMADE, ProductSellingStatus.SELLING, "아메리카노", 4000);
+        Product product2 = createProduct("002", ProductType.HANDMADE, ProductSellingStatus.HOLD, "카페라떼", 4500);
+        Product product3 = createProduct("003", ProductType.HANDMADE, ProductSellingStatus.STOP_SELLING, "팥빙수", 7000);
 
 
-        Product product3 = Product.builder()
-                .productNumber("003")
-                .type(ProductType.HANDMADE)
-                .sellingStatus(ProductSellingStatus.STOP_SELLING)
-                .name("팥빙수")
-                .price(7000)
-                .build();
 
         productRepository.saveAll(List.of(product1, product2, product3));
 
@@ -64,11 +43,11 @@ class ProductRepositoryTest {
         // then
 
 
-        Assertions.assertThat(products).hasSize(2)
+        assertThat(products).hasSize(2)
                 .extracting("productNumber", "name", "sellingStatus")
                 .containsExactlyInAnyOrder(
                         Tuple.tuple("001", "아메리카노", ProductSellingStatus.SELLING),
-                        Tuple.tuple("002", "카폐라떼", ProductSellingStatus.HOLD)
+                        Tuple.tuple("002", "카페라떼", ProductSellingStatus.HOLD)
                 ); // list 할 때 주로 이렇게 하심
     }
 
@@ -76,37 +55,13 @@ class ProductRepositoryTest {
 
     @DisplayName("상품 번호 리스트로 상품들을 줘야한다.")
     @Test
-    void findAllByProductNumberIn(){
+    void findAllByProductNumberIn() {
 
         // given
-        Product product1 = Product.builder()
-                .productNumber("001")
-                .type(ProductType.HANDMADE)
-                .sellingStatus(ProductSellingStatus.SELLING)
-                .name("아메리카노")
-                .price(4000)
-                .build();
-
-        Product product2 = Product.builder()
-                .productNumber("002")
-                .type(ProductType.HANDMADE)
-                .sellingStatus(ProductSellingStatus.HOLD)
-                .name("카폐라떼")
-                .price(4500)
-                .build();
-
-
-        Product product3 = Product.builder()
-                .productNumber("003")
-                .type(ProductType.HANDMADE)
-                .sellingStatus(ProductSellingStatus.STOP_SELLING)
-                .name("팥빙수")
-                .price(7000)
-                .build();
-
+        Product product1 = createProduct("001", ProductType.HANDMADE, ProductSellingStatus.SELLING, "아메리카노", 4000);
+        Product product2 = createProduct("002", ProductType.HANDMADE, ProductSellingStatus.HOLD, "카페라떼", 4500);
+        Product product3 = createProduct("003", ProductType.HANDMADE, ProductSellingStatus.STOP_SELLING, "팥빙수", 7000);
         productRepository.saveAll(List.of(product1, product2, product3));
-
-
 
         // when
         List<Product> products = productRepository.findAllByProductNumberIn(List.of("001", "002"));
@@ -115,14 +70,62 @@ class ProductRepositoryTest {
         // then
 
 
-        Assertions.assertThat(products).hasSize(2)
+        assertThat(products).hasSize(2)
                 .extracting("productNumber", "name", "sellingStatus")
                 .containsExactlyInAnyOrder(
                         Tuple.tuple("001", "아메리카노", ProductSellingStatus.SELLING),
-                        Tuple.tuple("002", "카폐라떼", ProductSellingStatus.HOLD)
+                        Tuple.tuple("002", "카페라떼", ProductSellingStatus.HOLD)
                 ); // list 할 때 주로 이렇게 하심
+    }
 
 
+
+    @DisplayName("가장 마지막으로 저장된 상품번호를 읽어온다.")
+    @Test
+    void findLatestProduct(){
+
+        // given
+        String targetProductNumber = "003";
+
+        Product product1 = createProduct("001", ProductType.HANDMADE, ProductSellingStatus.SELLING, "아메리카노", 4000);
+        Product product2 = createProduct("002", ProductType.HANDMADE, ProductSellingStatus.HOLD, "카페라떼", 4500);
+        Product product3 = createProduct(targetProductNumber, ProductType.HANDMADE, ProductSellingStatus.STOP_SELLING, "팥빙수", 7000);
+
+
+        productRepository.saveAll(List.of(product1, product2, product3));
+
+        // when
+        String latestProductNumber = productRepository.findLatestProduct();
+
+
+        // then
+        assertThat(latestProductNumber).isEqualTo(targetProductNumber);
+
+    }
+
+
+    @DisplayName("가장 마지막으로 저장한 상품의 상품번호를 읽어올 때, 상품이 하나도 없는 경우에는 null을 반환한다.")
+    @Test
+    void findLatestProductWhenProductIsEmpty(){
+        // when
+        String latestProductNumber = productRepository.findLatestProduct();
+
+
+        // then
+        assertThat(latestProductNumber).isNull();
+
+    }
+
+    private Product createProduct(String productNumber, ProductType type, ProductSellingStatus sellingStatus
+    ,String name, int price
+    ) {
+        return Product.builder()
+                .productNumber(productNumber)
+                .type(type)
+                .sellingStatus(sellingStatus)
+                .name(name)
+                .price(price)
+                .build();
     }
 
 


### PR DESCRIPTION
## 1차시

- 외부 세계의 요청을 가장 먼저 받는 계층
- 파라미터에 대한 최소한의 검증을 수행한다.

- 이번 테스트에서는 presentation 만을 위한 테스트이다! 비즈니스, infra 레이어에 대해서는 모킹을 통해 진행한다.

### Mock

- tmi : mocktail 이라는걸 몰디브에는 판다
- 내가 테스트하고 싶은거에 집중하기 위해 너무 많음! 의존관계 엮인거..? 으…
- 그래서 가짜로 만듦

### MockMvc

- spring MVC 동작을 재현할 수 있는 테스트 프레임워크

### 요구사항

- 관리자 페이지에서 신규 상품을 등록할 수 있다.
- 상품명, 상품 타입, 판매 상태, 가격 등을 입력받는다.

### 처음 테스트를 만들 때 → service 랑 repo 랑 구분 안 갈 수 있다.

- 초기 테스트를 만들어가는 과정은 사실 repository 테스트랑 service 테스트랑 구분이 안되는 순간들이 있는데 그 문제는 이후에 service 가 조금 더 고도화되고 요구사항들이 추가되면 분리가 자연스럽게 되어진다!
- 그래서 결론은! 분리를 좀 해라!

### Java 문법 - String format 잘 사용하기!

- 구현을 따라가다 해당 부분에서 살짝 뇌정지가 왔다.

```java
        return String.format("%03d", nextProductNumberInt);
```

- 다시 정리해보면!
    - %3d 이렇게 하게 되면 최소 3칸을 차지하는 친구이다! 제일 오른쪽부터 값이 채워진다!
    - 거기에 %0 을 넣으면 왼쪽의 빈 칸들에 0을 채워준다!
    - 문제는 이 친구들은 숫자형일때만 사용 가능하다! 문자열을 포맷팅할 때는 가능하지 않다.
    - 응용하려면 “%06.2f” 이 형태로 만들어보면 될 거 같다!

### 현재 로직에서 발생할 수 있는 문제

```java
    @Transactional
    public ProductResponse createProduct(ProductCreateRequest request) {
        // nextProductNumber
        String nextProductNumber = createNextProductNumber();

        Product product = request.toEntity(nextProductNumber);
        Product savedProduct = productRepository.save(product);

        return ProductResponse.of(savedProduct);
    }
```

- 관리자가 한 명은 아니기에 동시에 여러명이 해당 요청을 날리게 될 경우 동시성 문제가 발생하게 된다!
- 이를 해결하기 위해
    - unique index를 이용하여 해당 값이 존재하면 재시도 하면서 올바르게 넣는 방식
    - 동시 접속이 너무 많다면! UUID를 이용하여 해결하는 방식! 이 있다.
- 적절한 방법을 활용하여서 해당 문제를 이후에 해결하기 바람..!

### @Transactional(readOnly = true) - CQRS? (Command Query Responsibility Segreagation)

- 우선 readOnly 얘기!
    - 읽기 전용 트랜잭션 실행이다.
    - cud 작업은 동작하지 않는 작업이 된다! onlyRead만 가능하다! 조회만 가능하다는 얘기다!
- JPA : CUD 스냅샷 저장하고 이런 작업들이 원래는 진행되는데 readOnly로 인해 이 작업을 안한다! (성능이 향상이 되어진다)
- CQRS 라는 개념이 여기서 등장
- 영어로 참 어렵게 적었지만 쉽게 풀면 Command랑 Query를 분리해라! 이 말이다.
    - Command : CUD 같은 행위
    - Query : R 행위
- 되게 별 거 아닌 것처럼 보이지만! readOnly를 쓰면서 분리한것부터 CQRS 를 시작한것임! 그래서 이게 되게 중요함!
- 그래서 실제로 이런 서비스들을 아예 분리하기도함! 왜냐하면 실제로는 read : write = 8 : 2 수준이기 때문이다.
- 그래서 이렇게 분리하는데 db 엔드포인트로도 분리가 된다!
    - ex)  aws aurora db 등 클러스터 모드로 하게 되면 master slave → write용, read용 으로 분리되어서 보낼 수 있다!
    - spring 에 readOnly를 보고 엔드포인트를 다르게 줘서 보내줄 수도 있다!
- 그래서 강사님이 하고싶었던 말은! transactional 잘 걸기로 했는데 readOnly=true 처럼 이렇게 해주는 것을 query 용 행위, command 용 행위에 잘 나눠서 책임 분리했으면 좋겠음!
- 그런데 이렇게 할 때 매번 실수를 할 수 있으니 class 단위에 readOnly를 걸어버리고 command 행위라면 명시적으로 메서드에 지정해주는 방식을 해버리자!
- 이후에 cqrs 더 알아봐도 좋을 듯 !
- cqrs 관련 문서들
    - https://docs.aws.amazon.com/ko_kr/prescriptive-guidance/latest/modernization-data-persistence/cqrs-pattern.html
    - https://martinfowler.com/bliki/CQRS.html

## 2차시

### @WebMvcTest

- presentation test 를 위해 spring에서 제공해주는 친구

### MockMvc

- spring 의 mvc 기능을 사용하며 테스트를 해볼 수 있도록 도와주는 친구이다!

### 어떻게 하나? 예시!

```java
@DisplayName("신규 상품을 등록한다.")
    @Test
    void createProduct() throws Exception {
        //given
        ProductCreateRequest request = ProductCreateRequest.builder()
                .type(ProductType.HANDMADE)
                .sellingStatus(ProductSellingStatus.SELLING)
                .name("아메리카노")
                .price(4000)
                .build();

        //when //then
        mockMvc.perform(post("/api/v1/products/new")
                .content(objectMapper.writeValueAsString(request))
                .contentType(MediaType.APPLICATION_JSON)
        )
                .andDo(print())
                .andExpect(status().isOk());
    }
```

- .perform : 해당 url로 요청을 보내게 됨!
- objectMapper 라는 것을 통해 직렬화, 역직렬화를 도와주는 친구인데 우리가 데이터를 보내기 위해 필요한 친구이다!
- contentType : 어떤 형태로 보낼지
- andDo : 어떻게 가는지 자세하게 보기 위해 출력물을 찍어주기 위해 도와주는 친구이다.
- andExpect : 상태로 ok 라는 상태로 오게 된다.

### 정답은 아니긴 하지만! 봉투 패턴 과 같은 ApiResponse

```java
@Getter
public class ApiResponse<T> {

    private int code;
    private HttpStatus status;
    private String message;
    private T data;

    public ApiResponse(HttpStatus status, String message, T data) {
        this.code = status.value();
        this.status = status;
        this.message = message;
        this.data = data;
    }

    public static <T> ApiResponse<T> of(HttpStatus status, String message, T data) {
        return new ApiResponse<>(status, message, data);
    }

    public static <T> ApiResponse<T> of(HttpStatus status, T data) {
        return of(status, status.name(), data);
    }

    public static <T> ApiResponse<T> ok(T data) {
        return of(HttpStatus.OK, HttpStatus.OK.name(), data);
    }

}
```

- 해당 형태가 정답은 아니지만 테스트를 하고 해당 형태로 잘 오는지 확인하기 위해 제네릭을 활용하여 진행

### 그래서 이를 활용해

```java
    @DisplayName("신규 상품을 등록할 때 상품 타입은 필수값이다.")
    @Test
    void createProductWithoutType() throws Exception {
        //given
        ProductCreateRequest request = ProductCreateRequest.builder()
                .sellingStatus(ProductSellingStatus.SELLING)
                .name("아메리카노")
                .price(4000)
                .build();

        //when //then
        mockMvc.perform(post("/api/v1/products/new")
                        .content(objectMapper.writeValueAsString(request))
                        .contentType(MediaType.APPLICATION_JSON)
                )
                .andDo(print())
                .andExpect(status().isBadRequest())
                .andExpect(jsonPath("$.code").value(400))
                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
                .andExpect(jsonPath("$.message").value("상품 타입은 필수입니다."))
                .andExpect(jsonPath("$.data").isEmpty());
    }

```

- 다음과 같이 테스트가 가능하였다!
- 이를 통해 더 일관적인 테스트를 볼 수 있기에 다른 테스트를 작성할 때도 더 유용하게 사용할 수 있다!

### @Valid 를 활용하여 쉽게 dto 의 필드에 대한 validation 진행

```java
    	@NotBlank(message = "상품 이름은 필수입니다.")// notblank는 문자가 필수로 있어야 한다!
    //@NotNull // "" "  " 요건 허용이 됨!
    //@NotEmpty // ""  이것만 아니면 통과! 공백은 허용!
    // String name -> 상품 이름은 20자 제한 이렇게 도메인 정책
    //@Max(20) // 이걸 여기서 해야하는게 맞나? 책임이 맞나? 고민해봐야함!
    // 왜냐? 우리만 사실 도메인 정책에서 사용하는 그런 성격의 정책이라면? 특수한 정책이라면? 구분해야함!
    // 그래서 우리는 하나의 밸리데이션으로 보이더라도 어느 레이어에서 검증할지 한 번에 한 레이어에서 할 필요는 없음!
    // 책임을 어떻게 분리하면 좋을지 생각!
    private String name;
    @NotNull(message = "상품 타입은 필수입니다.")
    private ProductType type;
    @NotNull(message = "상품 판매상태는 필수입니다.")
    private ProductSellingStatus sellingStatus;
    @Positive(message = "상품 가격은 양수여야 합니다.")
    private int price;

```

- 여기서 다른 친구들은 자주 봤을 수 있지만! 이 친구들을 활용하면 쉽게 request 로 오는 값들에 대한 검증이 가능하다!
- 그런데 헷갈릴만한 친구가 있다!
    - @NotBlank : 문자가 필수로 있어야 한다!
    - @NotNull : 공백은 허용됨!, 비어있는 형태도 허용!
    - @NotEmpty : “” 이 경우만 아니면 다 통과
- 여기서 고민할 부분! 도메인 특성상 걸리는 정책의 validation 에 대해서는 이 계층에서의 책임일까?
    - 해당 부분에서는 고민을 해야함! 진짜 도메인 한정적으로 정책이 걸리는 경우는 되게 특수한 경우이기 때문에 더 깊숙한 서비스에서 걸러내어서 오류를 처리해야할 수도 있는 것이다!
    - 그래서 이런 부분 잘 생각하고 책임 분리 잘 할 수 있도록!

### 어디까지 dto 분리해줘야할까?

- 사실 진짜 중요한 부분이다! 궁금하기도 했던 부분이기도 하고!
- 결론부터 말하면 계층별로 dto 분리를 시켜주는 것이 좋다! 그런 형태가 오히려 계층적으로 이상하게 의존하지 않기 때문이다! ex) service → controller

- 사실은 지금 처음의 CreateRequest 형태로 받았었는데 이는 presentation 에서만 있을 수 있게 하는 것이좋다! 왜냐하면 @Valid 와 관련된 검증이 진행되기 때문이다! 그 역할은 온전히 presentation에만 있도록 분류할 수 있기 때문이다.
- 그래서 controller → service 로 갈 때는 조금 더 분리해서 service 가 받을 수있는 dto로 변환시켜주는 작업을 통해 보내줄 수 있다.

### controller, service 용 dto 분리

```java
controller 용 dto
@Getter
@NoArgsConstructor
public class ProductCreateRequest {

    @NotBlank(message = "상품 이름은 필수입니다.")// notblank는 문자가 필수로 있어야 한다!
    private String name;
    @NotNull(message = "상품 타입은 필수입니다.")
    private ProductType type;
    @NotNull(message = "상품 판매상태는 필수입니다.")
    private ProductSellingStatus sellingStatus;
    @Positive(message = "상품 가격은 양수여야 합니다.")
    private int price;
    
    @Builder
    private ProductCreateRequest(String name, ProductType type, ProductSellingStatus sellingStatus, int price) {
        this.name = name;
        this.type = type;
        this.sellingStatus = sellingStatus;
        this.price = price;
    }

    public ProductServiceRequest toServiceRequest(){
        return ProductServiceRequest.builder()
                .name(name)
                .type(type)
                .sellingStatus(sellingStatus)
                .price(price)
                .build();
    }

}

---

service 용 dto

public class ProductServiceRequest {
    private String name;
    private ProductType type;
    private ProductSellingStatus sellingStatus;
    private int price;

    @Builder
    private ProductServiceRequest(String name, ProductType type, ProductSellingStatus sellingStatus, int price) {
        this.name = name;
        this.type = type;
        this.sellingStatus = sellingStatus;
        this.price = price;
    }

    public Product toEntity(String nextProductNumber) {
        return Product.builder()
                .productNumber(nextProductNumber)
                .name(name)
                .type(type)
                .price(price)
                .sellingStatus(sellingStatus)
                .build();
    }

}
```

### 분리 이후 로직에서의 사용

```java
  public ApiResponse<ProductResponse> createProduct(@Valid @RequestBody ProductCreateRequest request){
        return ApiResponse.of(HttpStatus.OK, productService.createProduct(request.toServiceRequest()));
    }
    
    
    
    @Transactional
    public ProductResponse createProduct(ProductServiceRequest request) {
        // nextProductNumber
        String nextProductNumber = createNextProductNumber();

        Product product = request.toEntity(nextProductNumber);
        Product savedProduct = productRepository.save(product);

        return ProductResponse.of(savedProduct);
    }
```

- 요런 형태로 변환이 되어서 실제로 service → controller 의 의존이 아예 없어질 수 있게 된다! 이후의 확장성을 고려하면 이런 귀찮음들이 많지만 미래를 보고 더 확장성 있고 유연할 수 있게 하는 설계대로 가는것이 좋은 방향이다!