### PR TITLE
feat #21 @Mock, @InjectMocks, @Spy 학습 구현

### DIFF
--- a/src/main/java/sample/cafekiosk/spring/api/service/mail/MailService.java
+++ b/src/main/java/sample/cafekiosk/spring/api/service/mail/MailService.java
@@ -15,7 +15,7 @@ public class MailService {
 
     public boolean sendMail(String fromEmail, String toEmail, String subject, String content) {
 
-        boolean result= mailSendClient.sendEmail(fromEmail, toEmail, subject, content);
+        boolean result= mailSendClient.sendEmail(fromEmail, toEmail, subject, content); // 요것만 stubbing 다른건 동일하게 작동 이럴때 spy 활용
 
         if(result) {
             mailSendHistoryRepository.save(MailSendHistory.builder()
@@ -24,6 +24,11 @@ public class MailService {
                     .subject(subject)
                     .content(content)
                     .build());
+
+            mailSendClient.a();
+            mailSendClient.b();
+
+
             return true;
         }
         return false;

--- a/src/main/java/sample/cafekiosk/spring/client/mail/MailSendClient.java
+++ b/src/main/java/sample/cafekiosk/spring/client/mail/MailSendClient.java
@@ -14,4 +14,12 @@ public class MailSendClient {
         log.info("메일 전송");
         throw new IllegalArgumentException("메일 전송");
     }
+
+    public void a(){
+        log.info("a");
+    }
+
+    public void b(){
+        log.info("b");
+    }
 }

--- a/src/test/java/sample/cafekiosk/spring/api/service/mail/MailServiceTest.java
+++ b/src/test/java/sample/cafekiosk/spring/api/service/mail/MailServiceTest.java
@@ -1,0 +1,63 @@
+package sample.cafekiosk.spring.api.service.mail;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sample.cafekiosk.spring.client.mail.MailSendClient;
+import sample.cafekiosk.spring.domain.history.mail.MailSendHistory;
+import sample.cafekiosk.spring.domain.history.mail.MailSendHistoryRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MailServiceTest {
+
+    @Spy // 실제 객체를 기반으로 만들어짐!, 일부만 쓰고 일부만 모킹하고 싶을때 사용
+    //@Mock
+    private MailSendClient mailSendClient; // 더 편하게 작성 extendwith mockitoExtension.class 같이 써야함
+
+    @Mock
+    private MailSendHistoryRepository mailSendHistoryRepository;
+
+    @InjectMocks // Mock으로 선언된 친구를 해당 어노테이션 지정된 클래스에 넣어준다.
+    private MailService mailService;
+
+
+    @DisplayName("메일 전송 테스트")
+    @Test
+    void test(){
+        //given
+
+//        when(mailSendClient.sendEmail(anyString(), anyString(), anyString(), anyString()))
+//                .thenReturn(true); @mock 일때
+
+        doReturn(true) // spy 일때 활용하는 방시
+                .when(mailSendClient).sendEmail(anyString(), anyString(), anyString(), anyString());
+
+//
+//        when(mailSendHistoryRepository.save(any(MailSendHistory.class)))
+//                .thenReturn()
+        // mock 객체만 만들면 기본값을 던짐 -> 빈 값
+
+        //when
+        boolean result = mailService.sendMail("", "", "", "");
+
+        Mockito.verify(mailSendHistoryRepository, times(1)).save(any(MailSendHistory.class));
+
+
+        //then
+        assertThat(result).isTrue();
+
+    }
+
+
+}

--- a/src/test/java/sample/cafekiosk/spring/api/service/order/OrderStatisticsServiceTest.java
+++ b/src/test/java/sample/cafekiosk/spring/api/service/order/OrderStatisticsServiceTest.java
@@ -44,7 +44,7 @@ class OrderStatisticsServiceTest {
     @Autowired
     private OrderProductRepository orderProductRepository;
 
-    @MockBean
+    @MockBean // context 가 떠야 효과가 있는 친구임!
     private MailSendClient mailSendClient;
 
     @AfterEach


### PR DESCRIPTION
## 코드를 보면서 얘기해보자!

```java
@ExtendWith(MockitoExtension.class)
class MailServiceTest {

    @Spy // 실제 객체를 기반으로 만들어짐!, 일부만 쓰고 일부만 모킹하고 싶을때 사용
    //@Mock
    private MailSendClient mailSendClient; // 더 편하게 작성 extendwith mockitoExtension.class 같이 써야함

    @Mock
    private MailSendHistoryRepository mailSendHistoryRepository;

    @InjectMocks // Mock으로 선언된 친구를 해당 어노테이션 지정된 클래스에 넣어준다.
    private MailService mailService;

    @DisplayName("메일 전송 테스트")
    @Test
    void test(){
        //given

//        when(mailSendClient.sendEmail(anyString(), anyString(), anyString(), anyString()))
//                .thenReturn(true); @mock 일때

        doReturn(true) // spy 일때 활용하는 방시
                .when(mailSendClient).sendEmail(anyString(), anyString(), anyString(), anyString());

//
//        when(mailSendHistoryRepository.save(any(MailSendHistory.class)))
//                .thenReturn()
        // mock 객체만 만들면 기본값을 던짐 -> 빈 값

        //when
        boolean result = mailService.sendMail("", "", "", "");

        Mockito.verify(mailSendHistoryRepository, times(1)).save(any(MailSendHistory.class));

        //then
        assertThat(result).isTrue();

    }

}
```

@Mock : 해당 친구는 아예 가짜 객체를 만들어버림! 그래서 stubbing 하지 않으면 그냥 기본값을 뱉어버리는 정책이 있음! Mockito.mock 안으로 가보기!

@InjectMocks : @Mock으로 만들어진 친구들을 해당 객체로 주입을 시켜주는 역할을 함!

@Spy : 일부 기능에 대해서는 정상적으로 작동시키게 하고 나머지 기능에 대해서는 stubbing을 하고 싶을 때 주로 사용한다!

그래서 사용방식이 when 절 바로 쓰는게 아니라 doReturn 을 통해 지정하고 실행을 한다!

지금 현재 원래는 어노테이션을 사용안하여도 이렇게 쓸 수 있지만 어노테이션을 사용하고 싶다면!  

@ExtendwWith(MockitoExtension.class) 를 사용해야 활용할 수 있다!

### Spy를 안찍고 Mock을 찍으면

```java
14:33:15.136 [main] INFO sample.cafekiosk.spring.client.mail.MailSendClient -- a
14:33:15.145 [main] INFO sample.cafekiosk.spring.client.mail.MailSendClient -- b
```

해당 로그가 안나오고 Spy를 찍어야만 해당 로그가 나온다! 이를 통해 Spy를 선언한 친구는 일부 동작에 대해서는 실제로 동작하는 것처럼 동작시켜준다는 것을 알 수 있다.