### PR TITLE
feat #27 테스트 환경의 독립성을 보장하자! 학습

### DIFF
--- a/src/test/java/sample/cafekiosk/spring/api/service/order/OrderServiceTest.java
+++ b/src/test/java/sample/cafekiosk/spring/api/service/order/OrderServiceTest.java
@@ -210,6 +210,12 @@ class OrderServiceTest {
         Stock stock2 = Stock.create("002", 2);
 
         stock1.deductQuantity(1); // todo : 이런식으로 하면 안됨!
+        // createOrder 가 주 행위임! 재고 차단이라는 다른 행위를 가져다 썼음!
+        // 1. 다른 맥락의 친구가 들어옴! 논리적 사고를 한 번 더 진행해야한다는 것임!
+        // 2. deductQuantity 가 잘못될 경우! createOrder 가 잘못될 수 있음! 앞의 given 절 하다가 테스트를 실패한 것임! 이건 좀...! 이후에 테스트 왜 깨졌는지 유추하기가 어려워짐! 조금 더 커지면!
+        // 그래서 웬만하면 생성자 기반으로 테스트 진행하면 좋음! 순수한 생성자나 빌더로 구성하는게 좋음! 팩토리 메서드도 어떤 의도를 가지고 만든 것임!
+        // 팩토리 메서드도 어떤 목적이 있음! ex) 어떤 인자를 받고 싶다거나, 어떤 거 전에 검증을 하거나
+        // 그래서 given절은 웬만하면 생성자들을 구성으로 오게 하거나 API 들을 최대한 사용하지 않고 독립적으로 할 수 있도록 하는것이 좋다!
 
         stockRepository.saveAll(List.of(stock1, stock2));
 


### PR DESCRIPTION
## 테스트 환경에서 다른 api 들을 사용했을 때?

- deductQuantity 라는 친구 쓸 때 나중에 보자고 한 친구가 있었음!

```java
    @DisplayName("재고가 부족한 상품으로 주문을 생성하려는 경우 예외가 발생한다.")
    @Test
    void createOrderWithNoStock(){
        //given 테스트 준비 단계는 모두 given
        LocalDateTime registeredTime = LocalDateTime.now();

        Product product1 = createProduct(ProductType.BOTTLE, "001", 1000);
        Product product2 = createProduct(ProductType.BAKERY, "002", 3000);
        Product product3 = createProduct(ProductType.HANDMADE, "003", 5000);
        productRepository.saveAll(List.of(product1, product2, product3));

        Stock stock1 = Stock.create("001", 2);
        Stock stock2 = Stock.create("002", 2);

        stock1.deductQuantity(1); // todo : 이런식으로 하면 안됨!
        
        stockRepository.saveAll(List.of(stock1, stock2));

        OrderCreateServiceRequest request = OrderCreateServiceRequest.builder()
                .productNumbers(List.of("001", "001", "002", "003"))
                .build();

        //when //then
        assertThatThrownBy(() -> orderService.createOrder(request, registeredTime))
                .isInstanceOf(IllegalArgumentException.class)
                .hasMessage("재고가 부족한 상품이 있습니다.");
```

   사실 이 친구를 문제라고 했던 이유는 주 관심사가 이 친구가 아니라 createOrder 이기 때문임! 뭐 이렇게 볼 수도 있지만 다른 이유들도 있음

1. 다른 맥락의 친구인 deductQuantity 때문에 논리적 사고를 누군가 한 번 더 하면서 읽어야함!
2. deductQuantity 가 잘못된 경우 createOrder 에 영향이 감! 앞의 given 절 하다가 테스트가 깨지게 된다는 것임!

그래서 웬만하면 테스트를 진행할때는 생성자, 빌더 기반으로 구성되어있는 친구를 가지고 하는게 좋음!

그러면 팩토리 메서드는? → 이 친구도 사실 어떻게 보면 문제임! 코드 작성자가 사실 의도를 가지고 팩토리 메서드를 만든 것이니까!  ex) 어떤 인자를 받고 싶다거나, 어떤 거 전에 검증을 하거나

그래서 given절에 오는 구문들은 웬만하면 생성자들을 구성으로 오게 하거나 API 들을 최대한 사용을 지양하고 독립적으로 환경을 구성할 수 있도록 하는 것이 좋다.