### PR TITLE
feat #29 한 눈에 들어오는 Test Fixture 구성하기 학습

### DIFF
--- a/src/test/java/sample/cafekiosk/spring/api/service/product/ProductServiceTest.java
+++ b/src/test/java/sample/cafekiosk/spring/api/service/product/ProductServiceTest.java
@@ -1,9 +1,7 @@
 package sample.cafekiosk.spring.api.service.product;
 
 import org.assertj.core.groups.Tuple;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -29,6 +27,18 @@ class ProductServiceTest {
     @Autowired
     private ProductRepository productRepository;
 
+    @BeforeAll
+    static void beforeAll() {
+        // before class
+    }
+
+    @BeforeEach
+    void setUp() {
+        // before method
+
+        // 각 테스트 입장에서 봤을 때 ; 아예 몰라도 테스트 내용을 이해하는 데에 문제가 없는가?
+        // 수정해도 모든 테스트에 영향을 주지 않는가?
+    }
 
     @AfterEach
     void tearDown() {


### PR DESCRIPTION
## Test Fixture

- Fixture : 고정물, 고정되어 있는 물체
- 테스트를 위해 원하는 상태로 고정시킨 일련의 객체 → given 절을 구성할 때 사용한 친구들

## 공통된 친구들을 다 묶어버릴까?

- test 에 보면 given 절에 어찌보면 겹칠 수 있음! 그러면 이걸 before each all 과정에 다 합쳐버려?
    - 이렇게 하면 공유 변수를 사용했을때랑 비슷하게 문제 상황이 발생!
    - setUp에 구성을 하면 테스트 클래스가 엄청 길어졌다는 상황이 생겼는데 given 절 봤는데 별 아무말도 없어짐 그러면 스크롤 계속 위 아래로 왔다갔다가 해야한다는 것임. → 문서로서의 역할이 아무것도 안됨!
    - 문서로서의 테스트를 생각하면서 given절을 쓰면 좋겠다! 길어져도 이해가 잘 되면 좋은 given절일 수 있음!

## 1. 그럼 이 setUp Before 이런 친구들 언제 씀?

- `각 테스트 입장에서 봤을 때 ; 아예 몰라도 테스트 내용을 이해하는 데에 문제가 없는가?`
- `수정해도 모든 테스트에 영향을 주지 않는가?`
- 이를 만족하면 사용해도 됨!

## 2. Data.sql 도 given 절로서 활용?

- 이것도 하면 안 좋은 영향이 갈 수 있음!
    - 문서의 파편화가 되기 때문에!
    - 너무 많아지면 너무 관리하기가 어려움! 하나씩 다 바꿔주고 언제 다 하냐… ㅠㅠ (추천 x)

## 3. given 데이터 빌더 패턴이 길어져서 빼서 사용하였던 것

- 이 메서드를 빼놓을 때 테스트 클래스 내에서 필요한 값들만 남겨놓은게 좋을 거 같음!

```java
  private Product createProduct(String productNumber, ProductType type, ProductSellingStatus sellingStatus
            , String name, int price
    ) {
        return Product.builder()
                .productNumber(productNumber)
                .type(type)
                .sellingStatus(sellingStatus)
                .name(name) // 
                .price(price)
                .build();
    }
```

name 같은 친구가 테스트에 별로 안 중요하다! 그러면 파라미터에서 과감하게 빼고 고정 값으로 그냥 사용하는 것이 더 좋아보임! 그래서 꼭 필요한 필드만 명시를 하면 좋을 거 같다!

## 4. 빌더를 클래스마다 만들려니까 너무 귀찮음….. 이 친구 모아서 쓰면..?

- 뭐 이런 testFixture 들을 모아서 추상 클래스안에 다 때려박을 수 있음
    - 그런데 추천 안함!
    - 우리가 lombok을 이용해서 builder를 쓰고 있는데 파라미터가 매번 달라짐!
    - 그래서 매번 빌더가 달라짐!
    - 파라미터 수십개에 대해서 각기 다른 빌더를 만들면? 흠…. 관리가 안됨..
- 그래서 테스트 클래스마다 빌더를 뽑아서 사용하는것이 좋은 거 같음!
    - 사실 귀찮긴 함! → 코틀린 쓰면 어느정도 해결이 되긴 함
    - 코틀린에서 → 파라미터 지정자, 기본값 설정을 그냥 할 수 있음