### PR TITLE
Feat#28 데이터 클렌징 관련 수강

### DIFF
--- a/src/test/java/sample/cafekiosk/spring/domain/stock/StockTest.java
+++ b/src/test/java/sample/cafekiosk/spring/domain/stock/StockTest.java
@@ -9,6 +9,41 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class StockTest {
 
+    private static final Stock stock = Stock.create("001", 1);
+
+    @DisplayName("재고의 수량이 제공된 수량보다 작은지 확인한다. 공유 자원 사용")
+    @Test
+    void isQuantityLessThanEx(){
+        //given
+        int quantity = 2;
+
+        //when
+        boolean result = stock.isQuantityLessThan(quantity);
+
+        //then
+        assertThat(result).isTrue();
+
+    }
+
+
+    @DisplayName("재고를 주어진 개수만큼 차감할 수 있다. 공유 자원 사용")
+    @Test
+    void deductQuantityEx(){
+        //given
+        int quantity = 1;
+
+
+        //when
+        stock.deductQuantity(quantity);
+
+
+        //then
+        assertThat(stock.getQuantity()).isZero();
+    }
+
+
+
+
     @DisplayName("재고의 수량이 제공된 수량보다 작은지 확인한다.")
     @Test
     void isQuantityLessThan(){


### PR DESCRIPTION
## 사실 deleteAll deleteAllInBatch 얘기

## 데이터 클렌징

- 이전에 order, product 만 쓰지만 orderProduct도 같이 진행함!
- 사실 orderProduct 로 매핑된 친구가 남아있기 때문에 가져와서 지운 작업이 있었음.
- deleteAllInBatch → bulk 성으로 delete 할 수 있는데 외래키 조건을 조금 고려를 해야함!
    - deleteAll보다는 위가 더 좋은 거 같음!
- 그냥 delete 하면? 못 보던 select 가 생김! 전체 테이블을 조회하게 됨! 그 다음에 order_product를 지움! 건당 지우게 됨!
    - deleteAll 을 하게 될 경우 deleteAllInBatch 에 비해 너무 쿼리가 많아짐!
    - deleteAll의 장점? : order 지울때 orderProduct 를 같이 지워줄 것임!
        - 연관관계가 있는 친구들에 대해서 다 찾아서 지워버리는 작업을 함!
        - foreign key 맺고 있는 친구들 다 가져와서 지우는 과정도 진행함!
        - 신경 안써도 되는게 아님! foreign key 가 들어있어야 지울 수 있음! product 지우고 하면 그건 안됨!
        - 사실 전체 테스트 돌리는 것도 시간이자 자원임! In-Memory여도 많은 작업량이 생기기 때문에 시간적으로 비용이 든다고 할 수 있음!

### deleteAll 내부

```java
    @Transactional
    public void deleteAll() {
        Iterator var2 = this.findAll().iterator();

        while(var2.hasNext()) {
            T element = (Object)var2.next();
            this.delete(element);
        }

    }
```

findAll 이 불려짐! 그래서 잘 보고 쓰자! 

## 결론 : Transactional RollBack 방식과 deleteAll vs deleteAllInBatch 방식을 잘 알고 사용하자!

- 사실 강사님도 Transacional 사이드 이펙트만 고려해봤을때 괜찮으면 바로 Transactional을 사용하긴 함!