### PR TITLE
feat #36 restDocs 실습 구현 - ... 너무 복잡

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.5'
     id 'io.spring.dependency-management' version '1.1.6'
+    id("org.asciidoctor.jvm.convert") version "4.0.3"
+
 }
 
 group = 'sample'
@@ -17,6 +19,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt
 }
 
 repositories {
@@ -45,9 +48,42 @@ dependencies {
     //Guava
     implementation("com.google.guava:guava:33.3.1-jre")
 
+    //RestDocs
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
 
 }
 
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+
+ext { // 전역 변수
+    snippetsDir = file('build/generated-snippets')
+}
+
+test {
+    outputs.dir snippetsDir
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+
+    sources { // 특정 파일만 html로 만든다.
+        include("**/index.adoc")
+    }
+    baseDirFollowsSourceFile() // 다른 adoc 파일을 include 할 때 경로를 baseDir로 맞춘다.
+    dependsOn test
+}
+
+bootJar {
+    dependsOn asciidoctor
+    from("${asciidoctor.outputDir}") {
+        into 'static/docs'
+    }
+}
+
+

--- a/src/docs/asciidoc/api/product/product.adoc
+++ b/src/docs/asciidoc/api/product/product.adoc
@@ -1,0 +1,12 @@
+[[product-create]]
+=== 신규 상품 등록
+
+==== HTTP Request
+
+include::{snippets}/product-create/http-request.adoc[]
+include::{snippets}/product-create/request-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/product-create/http-response.adoc[]
+include::{snippets}/product-create/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,19 @@
+ifndef::snippets[]
+:snippets: ../../build/generated-snippets
+endif::[]
+= CafeKiosk REST API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+[[Product-API]]
+== Product API
+
+include::api/product/product.adoc[]
+
+
+
+

--- a/src/test/java/sample/cafekiosk/spring/docs/RestDocsSupport.java
+++ b/src/test/java/sample/cafekiosk/spring/docs/RestDocsSupport.java
@@ -1,0 +1,33 @@
+package sample.cafekiosk.spring.docs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MockMvcBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+
+@ExtendWith(RestDocumentationExtension.class)
+//@SpringBootTest // 이렇게 할 때 문서를 작성할때? 굳이 스프링 서버를 띄워야하나?
+public abstract class RestDocsSupport {
+
+    protected MockMvc mockMvc;
+    protected ObjectMapper objectMapper = new ObjectMapper();
+
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider provider){
+        this.mockMvc = MockMvcBuilders.standaloneSetup(initController()) // 이러면 스프링 의존성을 없애고 진행할 수 있음. 여기에 어느 컨트롤러 할 건지 넣어줘야함
+                .apply(documentationConfiguration(provider))
+                .build();
+    }
+
+    protected abstract Object initController();
+
+}

--- a/src/test/java/sample/cafekiosk/spring/docs/product/ProductControllerDocsTest.java
+++ b/src/test/java/sample/cafekiosk/spring/docs/product/ProductControllerDocsTest.java
@@ -1,0 +1,115 @@
+package sample.cafekiosk.spring.docs.product;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.snippet.Snippet;
+import sample.cafekiosk.spring.api.controller.product.ProductController;
+import sample.cafekiosk.spring.api.controller.product.dto.request.ProductCreateRequest;
+import sample.cafekiosk.spring.api.service.product.ProductService;
+import sample.cafekiosk.spring.api.service.product.request.ProductServiceRequest;
+import sample.cafekiosk.spring.api.service.product.response.ProductResponse;
+import sample.cafekiosk.spring.docs.RestDocsSupport;
+import sample.cafekiosk.spring.domain.product.ProductSellingStatus;
+import sample.cafekiosk.spring.domain.product.ProductType;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class ProductControllerDocsTest extends RestDocsSupport {
+
+    private final ProductService productService = Mockito.mock(ProductService.class);
+
+
+    @Override
+    protected Object initController() {
+        return new ProductController(productService);
+    }
+
+
+    @DisplayName("신규 상품을 등록하는 API")
+    @Test
+    void test() throws Exception {
+        //given
+        ProductCreateRequest request = ProductCreateRequest.builder()
+                .type(ProductType.HANDMADE)
+                .sellingStatus(ProductSellingStatus.SELLING)
+                .name("아메리카노")
+                .price(4000)
+                .build();
+
+
+        given(productService.createProduct(any(ProductServiceRequest.class)))
+                .willReturn(ProductResponse.builder()
+                        .id(1L)
+                        .productNumber("001")
+                        .type(ProductType.HANDMADE)
+                        .sellingStatus(ProductSellingStatus.SELLING)
+                        .price(4000)
+                        .name("아메리카노")
+                        .build()
+                );
+
+
+
+        //when //then
+        mockMvc.perform(post("/api/v1/products/new")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("product-create",
+                        preprocessRequest(prettyPrint()), // 예쁜 형태로 만들어주기 안 하면 json 이 한 줄로 나감
+                        preprocessResponse(prettyPrint()),
+
+                        requestFields(
+                                fieldWithPath("type").type(JsonFieldType.STRING)
+                                        .description("상품 타입"),
+                                fieldWithPath("sellingStatus").type(JsonFieldType.STRING)
+                                        .optional()
+                                        .description("상품 판매상태"),
+                                fieldWithPath("name").type(JsonFieldType.STRING)
+                                        .description("상품 이름"),
+                                fieldWithPath("price").type(JsonFieldType.NUMBER)
+                                        .description("상품 가격")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                                        .description("코드"),
+
+                                fieldWithPath("status").type(JsonFieldType.STRING)
+                                        .description("상태"),
+
+                                fieldWithPath("message").type(JsonFieldType.STRING)
+                                        .description("메시지"),
+                                fieldWithPath("data").type(JsonFieldType.OBJECT)
+                                        .description("응답 데이터"),
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER)
+                                        .description("상품 ID"),
+                                fieldWithPath("data.productNumber").type(JsonFieldType.STRING)
+                                        .description("상품 번호"),
+                                fieldWithPath("data.type").type(JsonFieldType.STRING)
+                                        .description("상품 타입"),
+                                fieldWithPath("data.sellingStatus").type(JsonFieldType.STRING)
+                                        .description("상품 판매상태"),
+                                fieldWithPath("data.name").type(JsonFieldType.STRING)
+                                        .description("상품 이름"),
+                                fieldWithPath("data.price").type(JsonFieldType.NUMBER)
+                                        .description("상품 가격")
+                                )
+                        ));
+        ;
+    }
+
+}
+

--- a/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,13 @@
+====Request Fields
+|===
+|Path|Type|Optional|Description
+
+{{#fields}}
+
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,0 +1,13 @@
+==== Response Fields
+|===
+|Path|Type|Optional|Description
+
+{{#fields}}
+
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+|===


### PR DESCRIPTION
## Spring Rest Docs

![image](https://github.com/user-attachments/assets/ca5d113c-69e7-4134-9db7-70d1016119f9)


- 테스트 코드를 통한 API 문서 자동화 도구
- API 명세를 문서로 만들고 외부에 제공함으로써 협업을 원할하게 한다.
- 기본적으로 AsciiDoc을 사용하여 문서를 작성한다.
    - AsciiDoc? 마크다운같은것

## REST Docs vs Swagger

### Rest Docs

- 장점
    - 테스트를 통과해야 문서가 만들어진다. (신뢰도가 높다.)
    - 프로덕션 코드에 비침투적이다.
- 단점
    - 코드 양이 많다.
    - 설정이 어렵다.

### Swagger

- 장점
    - 적용이 쉽다.
    - 문서에서 바로 API 호출을 수행해볼 수 있다.
- 단점
    - 프로덕션 코드에 침투적이다. → 어노테이션들을 컨트롤러에 달아서 진행하게 됨!
        - 코드가 조금 지저분해진다.
    - 테스트와 무관하기 때문에 신뢰도가 떨어질 수 있다.

아스키 독이라는 기법으로 사용하는데 → 이를 html로 바꿔주는 asciidoctor 라는 친구를 활용해서 진행한다.